### PR TITLE
Add mock post data to test server and redux usage

### DIFF
--- a/public/mock/posts.json
+++ b/public/mock/posts.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": 1,
+    "title": "Blog 1",
+    "creationDate": 1000,
+    "estimatedTimeToRead": 3,
+    "thumbnailUrl": "someUrl.png"
+  },
+  {
+    "id": 2,
+    "title": "Blog 2",
+    "creationDate": 1000,
+    "estimatedTimeToRead": 3,
+    "thumbnailUrl": "someUrl.png"
+  },
+  {
+    "id": 3,
+    "title": "Blog 3",
+    "creationDate": 1000,
+    "estimatedTimeToRead": 3,
+    "thumbnailUrl": "someUrl.png"
+  },
+  {
+    "id": 4,
+    "title": "Blog 4",
+    "creationDate": 1000,
+    "estimatedTimeToRead": 3,
+    "thumbnailUrl": "someUrl.png"
+  },
+  {
+    "id": 5,
+    "title": "Blog 5",
+    "creationDate": 1000,
+    "estimatedTimeToRead": 3,
+    "thumbnailUrl": "someUrl.png"
+  }
+]


### PR DESCRIPTION
## Description
Backend 구현 전 Server와 redux 연결을 테스트하기 위한 post mock data 추가

mock data는 다음의 주소로 접근할 수 있음 (_기본적으로 project의 `public` 아래의 directory는 해당 directory와 file명으로 접근_)
`localhost:3000/mock/posts.json`

이 주소로 `fetch `등을 통해 접근하여 해당 json의 data를 불러올 수 있음

![캡처](https://user-images.githubusercontent.com/45777630/210029309-2fa050c6-a613-4029-9cd6-d8f6b6b3b41e.PNG)

## TODO
**mock을 주입하는 형식만 정의하기 위한 PR임**. 때문에 이후에 필요한 데이터 (tagList, postBody, nextScrollId 등)은 redux를 구현하면서 논의(data의 형식 등)를 통해 함께 추가를 하는 방식으로 진행이 필요

## Cause
Backend 구현 전 Server와 redux 연결을 테스트하기 위한 mock data가 필요

## Feature to Test
`npm start`로 실행 후 `localhost:3000/mock/posts.json` 로 접근하여 post data가 정상적으로 보이는지 확인