### PR TITLE
Clarify license and origin file for copy of Ghost

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,13 @@
+/** 
+* Styles in this file are copy of global.css and screen.css in TryGhost/Casper.
+* Link of original file and code are attached to each style code.
+* Original license: https://github.com/TryGhost/Casper/blob/main/LICENSE
+*/
+
 /**
- * This class is correspond to gh-canvas class of Ghost Casper style
- */
+* Copy of .gh-canvas style of screen.css.
+* Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1298
+*/
 .BlogGrid {
   display: grid;
   grid-template-columns:
@@ -17,13 +24,18 @@
     [full-end];
 }
 
+/**
+* Copy of .gh-canvas > * style of screen.css.
+* Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1315
+*/
 .BlogGrid > * {
   grid-column: main-start / main-end;
 }
 
 /**
- * This is root style copy of screen.css of Ghost style
- */
+* Copy of :root style of screen.css.
+* Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L31
+*/
 :root {
   --color-green: #a4d037;
   --color-yellow: #fecd35;
@@ -46,6 +58,7 @@
 /**
  * Styles below are copy of global.css of Ghost style.
  * This styles are for setting default style of html tags.
+ * Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/global.css
  */
 html,
 body,

--- a/src/presentation/post/components/css/BlogPostBodyContent.css
+++ b/src/presentation/post/components/css/BlogPostBodyContent.css
@@ -3,7 +3,13 @@
 }
 
 /**
- * Styles from below are copy of gh-content style of Ghost casper.
+ * Below styles are copy of .gh-content related styles of screen.css in TryGhost/Casper.
+ * Original file and license are like below.
+ * Original file: 
+ *  From: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1340
+ *  To: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1504
+ * Original license: https://github.com/TryGhost/Casper/blob/main/LICENSE
+ * 
  * This is for html content which is converted from mark-down by ReactMarkdown component.
  */
 

--- a/src/presentation/post/components/css/BlogPostHeader.css
+++ b/src/presentation/post/components/css/BlogPostHeader.css
@@ -1,13 +1,31 @@
+/** 
+* Styles in this file are copy of screen.css in TryGhost/Casper.
+* Link of original file and code are attached to each style code.
+* Original license: https://github.com/TryGhost/Casper/blob/main/LICENSE
+*/
+
+/**
+* Copy of .article-header style of screen.css.
+* Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1224
+*/
 .BlogPostHeader {
   padding: 0 0 max(6.4vmin, 40px) 0;
 }
 
+/**
+* Copy of .article-image style of screen.css.
+* Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1261
+*/
 .BlogGrid .BlogPostHeader-thumbnail {
   width: 100%;
   margin: 0;
   grid-column: wide-start / wide-end;
 }
 
+/**
+* Copy of .article-image img style of screen.css.
+* Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1275
+*/
 .BlogPostHeader-thumbnail img {
   display: block;
   margin-left: auto;
@@ -16,6 +34,10 @@
   height: auto;
 }
 
+/**
+* Copy of .article-title style of screen.css.
+* Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1241
+*/
 .BlogPostHeader-title {
   margin-top: 0;
   margin-bottom: 0;
@@ -25,6 +47,12 @@
   color: var(--color-darkgrey);
 }
 
+/**
+* Copy of .article-byline and .article-byline-meta style of screen.css.
+* Original files: 
+*   https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1694
+*   https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1711
+*/
 .BlogPostHeader-description {
   display: flex;
   justify-content: space-between;

--- a/src/presentation/post/pages/css/BlogPostPage.css
+++ b/src/presentation/post/pages/css/BlogPostPage.css
@@ -1,3 +1,9 @@
+/** 
+* This is copy of .article of screen.css in TryGhost/Casper.
+* Original file and license are like below.
+* Original file: https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css#L1215
+* Original license: https://github.com/TryGhost/Casper/blob/main/LICENSE
+*/
 .BlogPostPage {
   padding: max(8vmin, 40px) 0 max(8vmin, 64px);
   word-break: normal;


### PR DESCRIPTION
## Description
Ghost의 Casper style은 MIT license로 사용이 자유로우나 기본적으로 license에 대한 고지 의무가 존재함.

현재 본 프로젝트에서는 Ghost module을 가져와서 사용하는 것이 아닌 일부 style의 code 스니펫을 복사하여 사용하기 때문에 별도 고지가 되어 있지 않은 상태이므로 각각의 copy에 original file과 license를 고지하도록 적용.

MIT license 의무 참고: https://www.olis.or.kr/license/Detailselect.do?lId=1006
## Cause
MIT License 고지 의무

## Feature to test
None - Only comment is added