### PR TITLE
[BlogHeader] Apply Ghost design to BlogHeader and Keyword Presenter

### DIFF
--- a/src/assets/loupe.svg
+++ b/src/assets/loupe.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" width="20" height="20"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>

--- a/src/presentation/header/components/css/BlogHeader.css
+++ b/src/presentation/header/components/css/BlogHeader.css
@@ -23,8 +23,7 @@
   align-items: center;
   height: 100%;
   margin: 0 auto;
-  max-width: 1200px;
-  width: 100%;
+  width: 95%;
 }
 
 .BlogHead-menu {

--- a/src/presentation/header/components/css/BlogHeader.css
+++ b/src/presentation/header/components/css/BlogHeader.css
@@ -1,5 +1,7 @@
-/*
-* Styles from below are copy of gh-content style of Ghost casper.
+/**
+* Styles in this file are modification of global.css and screen.css in TryGhost/Casper.
+* Link of original file and code are attached to each style code.
+* Original license: https://github.com/TryGhost/Casper/blob/main/LICENSE
 */
 
 .BlogHead {

--- a/src/presentation/header/components/css/BlogHeader.css
+++ b/src/presentation/header/components/css/BlogHeader.css
@@ -46,4 +46,5 @@
 
 .BlogHead-menu .nav li:hover {
   opacity: 0.9;
+  cursor: pointer;
 }

--- a/src/presentation/header/components/css/BlogHeader.css
+++ b/src/presentation/header/components/css/BlogHeader.css
@@ -1,16 +1,47 @@
-.BlogHeader {
-  text-align: left;
+/*
+* Styles from below are copy of gh-content style of Ghost casper.
+*/
+
+.BlogHead {
+  height: 125px;
+  font-size: 2rem;
+  line-height: 1.3em;
+  z-index: 150;
+  background-color: black;
+  color: #fff;
+  position: relative;
+  padding: 0 max(4vmin, 20px);
 }
 
-.BlogName {
-  display: inline-block;
-  font-size: 20px;
-  width: 100px;
-  margin-left: calc(50% - 50px);
-  margin-right: calc(45% - 15rem - 50px);
+.BlogHead-inner {
+  display: grid;
+  column-gap: 40px;
+  grid-template-columns: auto 1fr auto;
+  grid-auto-flow: row dense;
+  align-items: center;
+  height: 100%;
+  margin: 0 auto;
+  max-width: 1200px;
+  width: 100%;
 }
 
-hr {
-  /* To ignore default style of App.css */
-  margin: 0 !important;
+.BlogHead-menu {
+  display: flex;
+  align-items: center;
+  margin-top: 1px;
+  font-weight: 500;
+}
+
+.BlogHead-menu .nav {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 32px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.BlogHead-menu .nav li:hover {
+  opacity: 0.9;
 }

--- a/src/presentation/header/components/css/BlogHeaderSearchBar.css
+++ b/src/presentation/header/components/css/BlogHeaderSearchBar.css
@@ -1,23 +1,44 @@
-.BlogHeaderSearchBar {
-  display: inline-block;
-  margin: 3px 3px 3px auto;
-  border: 1px solid;
-  border-radius: 5px;
-  width: 15rem;
+/*
+* Styles from below are copy of gh-content style of Ghost casper.
+*/
+
+.BlogSearchBar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 24px;
+  list-style: none;
+  text-align: right;
 }
 
-.BlogHeaderSearchBar-loupe {
-  margin-left: 1%;
-  vertical-align: middle;
-  width: 7%;
-}
-
-.BlogHeaderSearchBar-input {
-  vertical-align: middle;
+.BlogSearchBar-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  cursor: pointer;
+  background-color: transparent;
   border: 0;
-  outline: 0;
-  width: 92%;
-  background-color: #f8f8f8;
-  /* To ignore default style of App.css */
-  box-sizing: border-box !important;
+  outline: none;
+}
+
+.BlogSearchBar-button:hover {
+  opacity: 0.9;
+}
+
+.BlogSearchBar-input {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 20px;
+  height: 30px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  font-size: 1.6rem;
+  border-radius: 48px;
+  color: var(--color-darkgrey);
+  background: #fff;
+  border: 1px solid black;
 }

--- a/src/presentation/header/components/css/BlogHeaderSearchBar.css
+++ b/src/presentation/header/components/css/BlogHeaderSearchBar.css
@@ -1,5 +1,7 @@
-/*
-* Styles from below are copy of gh-content style of Ghost casper.
+/**
+* Styles in this file are modification of global.css and screen.css in TryGhost/Casper.
+* Link of original file and code are attached to each style code.
+* Original license: https://github.com/TryGhost/Casper/blob/main/LICENSE
 */
 
 .BlogSearchBar {

--- a/src/presentation/header/components/ts/BlogHeader.tsx
+++ b/src/presentation/header/components/ts/BlogHeader.tsx
@@ -13,13 +13,16 @@ function BlogHeader() {
   }, [routerNavigate]);
 
   return (
-    <div className="BlogHeader">
-      <div className="BlogName" onClick={onClickSearchButton}>
-        {blogName}
+    <header className="BlogHead">
+      <div className="BlogHead-inner">
+        <nav className="BlogHead-menu" onClick={onClickSearchButton}>
+          <ul className="nav">
+            <li>{blogName}</li>
+          </ul>
+        </nav>
+        <BlogHeaderSearchBar />
       </div>
-      <BlogHeaderSearchBar />
-      <hr />
-    </div>
+    </header>
   );
 }
 

--- a/src/presentation/header/components/ts/BlogHeaderSearchBar.tsx
+++ b/src/presentation/header/components/ts/BlogHeaderSearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../css/BlogHeaderSearchBar.css';
-import loupeImage from '../../../../assets/loupeSmall.png';
+import { ReactComponent as LoupeImage } from '../../../../assets/loupe.svg';
 
 function BlogHeaderSearchBar() {
   const [query, setQuery] = useState('');
@@ -23,16 +23,12 @@ function BlogHeaderSearchBar() {
   }, [routerNavigate, searchResultPageUrl]);
 
   return (
-    <div className="BlogHeaderSearchBar">
+    <div className="BlogSearchBar">
+      <button className="BlogSearchBar-button" onClick={onClickSearchButton}>
+        <LoupeImage />
+      </button>
       <input
-        className="BlogHeaderSearchBar-loupe"
-        type="image"
-        src={loupeImage}
-        alt="Search Button"
-        onClick={onClickSearchButton}
-      />
-      <input
-        className="BlogHeaderSearchBar-input"
+        className="BlogSearchBar-input"
         type="search"
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={searchIfEnter}

--- a/src/presentation/searchPage/components/css/KeywordPresenter.css
+++ b/src/presentation/searchPage/components/css/KeywordPresenter.css
@@ -1,3 +1,9 @@
+/**
+* Styles in this file are modification of global.css and screen.css in TryGhost/Casper.
+* Link of original file and code are attached to each style code.
+* Original license: https://github.com/TryGhost/Casper/blob/main/LICENSE
+*/
+
 .KeywordPresenter {
   flex-wrap: wrap;
   width: 85%;

--- a/src/presentation/searchPage/components/css/KeywordPresenter.css
+++ b/src/presentation/searchPage/components/css/KeywordPresenter.css
@@ -2,19 +2,21 @@
   flex-wrap: wrap;
   width: 85%;
   margin: 1em auto 0 auto;
-  border-bottom: solid;
-}
-.KeywordHeader {
-  display: flex;
-  margin: 0.1em;
 }
 
-.KeywordHeader .loupe {
-  height: 1em;
-  width: auto;
-  margin: 0.1em 0 0 0.2em;
+.KeywordHeader {
+  margin-top: 30px;
+  font-size: 4.4rem;
 }
 
 .Keyword {
-  margin: 0.1em;
+  display: flex;
+  align-items: center;
+  width: auto;
+  margin: 0.1em 0 0 0.2em;
+  border-bottom: solid;
+}
+
+.Keyword h4 {
+  margin: 0;
 }

--- a/src/presentation/searchPage/components/ts/KeywordPresenter.tsx
+++ b/src/presentation/searchPage/components/ts/KeywordPresenter.tsx
@@ -1,5 +1,5 @@
-import loupeImage from '../../../../assets/loupeSmall.png';
 import '../css/KeywordPresenter.css';
+import { ReactComponent as LoupeImage } from '../../../../assets/loupe.svg';
 
 type KeywordPresenterProps = {
   keyword: string;
@@ -8,11 +8,11 @@ type KeywordPresenterProps = {
 function KeywordPresenter({ keyword }: KeywordPresenterProps) {
   return (
     <div className="KeywordPresenter">
-      <div className="KeywordHeader">
-        <div>검색 결과</div>
-        <img className="loupe" src={loupeImage} alt="Search Button" />
+      <h2 className="KeywordHeader">검색 결과</h2>
+      <div className="Keyword">
+        <LoupeImage />
+        <h4>{keyword}</h4>
       </div>
-      <div className="Keyword">{keyword}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Description
- Ghost casper design을 BlogHeader에 적용
- Search Page에서 Keyword Presentor 디자인 일부 변경
- 돋보기 이미지를 Casper에서 사용하는 벡터 이미지로 교체

### Detail
- https://github.com/WebBlogProject/web-blog-frontend/pull/32 에서 Ghost Casper의 global.css를 이미 적용한 상태라 global.css에서 따로 추가한 부분은 없음
- https://github.com/TryGhost/Casper/blob/main/assets/css/screen.css 에서 gh-head 클래스 참고
- Keyword Presenter의 경우 css를 변경하였으나 직접적으로 Casper에서 가져온 것은 없음. 레이 아웃을 참고하였음.

## 구현사항

f8153b9f8555b7b67ad699d7fcc117b4f7a875c7
- BlogHeader에 Ghost Design을 참고하여 css 변경
- 배경을 검은 색으로 변경

5c08e987b978c3184358fd3dbfb706518717285a
- BlogHeaderSearchBar를 Ghost Design을 참고하여 css 변경

1a6f10f386145c01d0de673997ebcdf1a27eb4f9
- 키워드 검색 후 나오는 디자인 수정


## 구현 결과

<img width="1298" alt="Screen Shot 2023-06-04 at 4 35 55 PM" src="https://github.com/WebBlogProject/web-blog-frontend/assets/48384542/df9a3c78-eec4-4443-87d9-35804daa7d7a">
